### PR TITLE
Add TLS support

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -17,6 +17,8 @@ type SearchTarget struct {
 	Url          string
 	TunnelUrl	 string	`json:"-"`
 	IndexPattern string
+	Cert         string
+	Key          string
 }
 
 type QueryDefinition struct {
@@ -74,6 +76,8 @@ func (c *Configuration) CopyConfigRelevantSettingsTo(dest *Configuration) {
 	//copy config relevant configuration settings
 	dest.SearchTarget.TunnelUrl = c.SearchTarget.TunnelUrl
 	dest.SearchTarget.Url = c.SearchTarget.Url
+	dest.SearchTarget.Cert = c.SearchTarget.Cert
+	dest.SearchTarget.Key = c.SearchTarget.Key
 	dest.SearchTarget.IndexPattern = c.SearchTarget.IndexPattern
 	dest.QueryDefinition.Format = c.QueryDefinition.Format
 	dest.QueryDefinition.Terms = make([]string, len(c.QueryDefinition.Terms))
@@ -152,6 +156,18 @@ func (config *Configuration) Flags() []cli.Flag {
 			Value:       "http://127.0.0.1:9200",
 			Usage:       "(*) ElasticSearch URL",
 			Destination: &config.SearchTarget.Url,
+		},
+		cli.StringFlag{
+			Name:        "cert",
+			Value:       "",
+			Usage:       "(*) certificate to use when accessing via TLS",
+			Destination: &config.SearchTarget.Cert,
+		},
+		cli.StringFlag{
+			Name:        "key",
+			Value:       "",
+			Usage:       "(*) key to use when accessing via TLS",
+			Destination: &config.SearchTarget.Key,
 		},
 		cli.StringFlag{
 			Name:        "f,format",
@@ -248,4 +264,3 @@ func IsConfigRelevantFlagSet(c *cli.Context) bool {
 	}
 	return false
 }
-


### PR DESCRIPTION
Add --key and --cert options for TLS access to Elasticsearch.  Both need
to be specified.

Addresses issue #22.