### PR TITLE
"Column view": Support confining interpolated fields to a desired length

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -156,7 +156,7 @@ func (config *Configuration) Flags() []cli.Flag {
 		cli.StringFlag{
 			Name:        "f,format",
 			Value:       "%message",
-			Usage:       "(*) Message format for the entries - field names are referenced using % sign, for example '%@timestamp %message'",
+			Usage:       "(*) Message format for the entries - field names are referenced using % sign, length with [n], for example '%@timestamp %message[55]'",
 			Destination: &config.QueryDefinition.Format,
 		},
 		cli.StringFlag{

--- a/elktail_test.go
+++ b/elktail_test.go
@@ -24,9 +24,29 @@ func TestResolveField(t *testing.T) {
 	testutils.AssertEqualsString(t, "", eval(model1, "bar"))
 }
 
-
-
 func eval(model interface{}, expr string) string {
 	result, _ := EvaluateExpression(model, expr)
 	return result
+}
+
+func TestFormatRegexp(t *testing.T) {
+	formatString := "%timestamp %message[25] %trace[10] %error"
+
+	match := FormatRegexp.FindAllStringSubmatch(formatString, -1)
+
+	testutils.AssertEqualsString(t, "%timestamp", match[0][0])
+	testutils.AssertEqualsString(t, "%timestamp", match[0][1])
+	testutils.AssertEqualsString(t, "", match[0][2])
+
+	testutils.AssertEqualsString(t, "%message[25]", match[1][0])
+	testutils.AssertEqualsString(t, "%message", match[1][1])
+	testutils.AssertEqualsString(t, "25", match[1][2])
+
+	testutils.AssertEqualsString(t, "%trace[10]", match[2][0])
+	testutils.AssertEqualsString(t, "%trace", match[2][1])
+	testutils.AssertEqualsString(t, "10", match[2][2])
+
+	testutils.AssertEqualsString(t, "%error", match[3][0])
+	testutils.AssertEqualsString(t, "%error", match[3][1])
+	testutils.AssertEqualsString(t, "", match[3][2])
 }


### PR DESCRIPTION
This introduces a simple modifier to field references specified in the format string:

Adding a suffix of the form `[<integer>]` will force the field value to be a string
of that length. The field value, whether it's blank, shorter, or longer than the
specified length will be of length `<integer>`. The consequence is a columnar output.

See commit message for a slightly longer explanation with a simple example.

I'm not entirely sure this fits a general desire and should be merged upstream,
but it fits a need that my organization has, and we'll be using it : )